### PR TITLE
Add routed Angular procurement forms

### DIFF
--- a/ClientApp/public/procurement/assets/main.css
+++ b/ClientApp/public/procurement/assets/main.css
@@ -1,0 +1,480 @@
+    :root {
+      --main-green: #217b59;
+      --main-green-light: #d3e6d5;
+      --gray-bg: #fff;
+      --gray-border: #ececec;
+      --heading-color: #1c2e23;
+      --text-color: #454545;
+      --status-success: #36b076;
+      --status-pending: #e4b913;
+      --status-danger: #d54f3c;
+      --main-radius: 14px;
+      --main-shadow: 0 4px 22px rgba(34,56,78,0.08);
+    }
+    body {
+      margin: 0; padding: 0;
+      font-family: 'DIN Next LT Arabic', 'Tajawal', 'Cairo', sans-serif;
+      background: var(--gray-bg);
+      color: var(--heading-color);
+      direction: rtl;
+      font-size: 17px;
+      line-height: 1.7;
+    }
+    .notification {
+      position: fixed; top:20px; left:50%;
+      transform: translateX(-50%);
+      background: #fff;
+      border:1.5px solid var(--main-green);
+      padding:14px 28px; border-radius:var(--main-radius);
+      box-shadow:0 6px 20px rgba(33,123,89,.15);
+      display:none; font-weight:600; z-index:999;
+      transition: opacity 0.3s;
+      font-size: 1.07em;
+    }
+    .role-switcher {
+      display:flex; justify-content:center; gap:18px; margin:30px 0 15px;
+      flex-wrap: wrap;
+    }
+    .role-btn {
+      padding:10px 24px; font-size:1.08em;
+      border:1.5px solid var(--main-green-light);
+      border-radius:var(--main-radius);
+      background:#fff; cursor:pointer;
+      transition: all .18s;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.03);
+      font-weight: 500;
+      outline: none;
+    }
+    .role-btn.active, .role-btn:focus, .role-btn:hover {
+      background: linear-gradient(90deg, var(--main-green) 85%, #22743d 100%);
+      color: #fff;
+      border-color: var(--main-green);
+      box-shadow: 0 3px 18px rgba(33,123,89,.10);
+    }
+    .steps-bar-wrapper {
+      max-width:940px; margin:0 auto 30px; padding:0 8px;
+    }
+    .steps-bar {
+      position:relative; display:flex;
+      justify-content:space-between; margin-bottom:24px;
+      align-items:flex-start;
+    }
+    #stepsSvg {
+      position:absolute; left:0; top:0; width:100%; height:123px; z-index:1; pointer-events:none;
+    }
+    #stepsSvg .main-line {
+      stroke:#c1e5c7; stroke-width:6; stroke-dasharray:6 4; fill:none;
+    }
+    #stepsSvg .branch-line {
+      stroke:#c1e5c7; stroke-width:6; fill:none; display:none;
+    }
+    #stepsSvg .progress-line {
+      stroke:var(--main-green); stroke-width:6; fill:none; display:none;
+      transition:stroke-dashoffset .4s;
+    }
+    #stepsSvg .progress-main { stroke-dasharray:6 4; }
+    .step-node {
+      z-index:3; flex:1;
+      display:flex; flex-direction:column;
+      align-items:center;
+    }
+    .step-node.sub-step { margin-top:101px; display:none; }
+    .step-icon {
+      width:44px; height:44px;
+      border:3px solid var(--main-green-light);
+      border-radius:50%;
+      background:#fff; display:flex;
+      align-items:center; justify-content:center;
+      color: var(--main-green);
+      font-size:1.8em;
+      margin-bottom:8px;
+      box-shadow:0 2px 10px rgba(33,123,89,.05);
+      transition:.22s;
+    }
+    .step-node.done .step-icon,
+    .step-node.active .step-icon {
+      background:linear-gradient(120deg,var(--main-green) 87%,#21894d 100%);
+      color:#fff; border-color:var(--main-green);
+      transform: scale(1.09);
+    }
+    .step-label {
+      font-size:1.04em; font-weight:600;
+      text-align:center; line-height:1.35em;
+      color: #5d786a;
+      letter-spacing: 0.2px;
+      background:#fff;
+      padding:0 4px;
+    }
+    .step-node.active .step-label { color:var(--main-green); }
+    .container {
+      max-width:940px; margin:0 auto 40px;
+      background:#fff;
+      border:1.5px solid var(--gray-border);
+      border-radius:var(--main-radius);
+      padding:32px 25px 32px 25px;
+      box-shadow:var(--main-shadow);
+      transition: box-shadow .25s;
+    }
+    h1 {
+      font-size:2.1rem; text-align:center;
+      color:var(--main-green); margin-bottom:28px;
+      display:flex; align-items:center;
+      justify-content:center; gap:10px;
+      letter-spacing: 0.1px;
+      font-weight: 700;
+    }
+    .details-box, .attachments-box, .action-final-box {
+      background:#fcfdfc;
+      border:1.2px solid var(--gray-border);
+      border-radius:14px;
+      padding:20px 18px 18px;
+      margin-bottom:26px;
+      box-shadow:0 1px 6px rgba(0,0,0,0.04);
+    }
+    .details-box p {
+      margin:11px 0; font-size:1em;
+      color:var(--text-color); display:flex;
+      align-items:center; gap:9px;
+    }
+    .details-box i { color:var(--main-green); }
+    label {
+      display:block; font-size:1em; font-weight:600; margin:13px 0 6px;
+      color: #24543b;
+    }
+    input, select, textarea {
+      width:100%; padding:12px; font-size:1em;
+      border:1.3px solid var(--main-green-light);
+      border-radius:10px;
+      background: #f6faf5;
+      margin-bottom: 2px;
+      transition: border-color .16s, box-shadow .16s;
+    }
+    input:focus, select:focus, textarea:focus {
+      border-color: var(--main-green);
+      outline: none;
+      box-shadow: 0 0 0 2px #e4f5eb;
+      background: #fff;
+    }
+    textarea { min-height:64px; resize:vertical; }
+    .attachments-box strong {
+      display:flex; align-items:center; gap:8px;
+      font-size:1.08em; margin-bottom:13px;
+      color: var(--main-green);
+    }
+    .attachments-box a {
+      display:flex; gap:8px; font-size:1em;
+      color:var(--main-green); text-decoration:none;
+      margin-bottom:10px; transition:.18s;
+      padding: 5px 0;
+    }
+    .attachments-box a:hover { text-decoration:underline; background: #f4fbf4; }
+    .attachments-box p {
+      font-size: .97em; color: #9d9c9c;
+      margin-top: 7px;
+    }
+    .template-links summary {
+      display:flex; align-items:center; gap:6px;
+      cursor:pointer; font-size:.97em; color:#9d9c9c;
+    }
+    .template-links .expand-icon {
+      transition: transform .2s;
+    }
+    .template-links[open] .expand-icon {
+      transform: rotate(180deg);
+    }
+    .template-links a { margin-bottom:6px; }
+    /* جداول النظام بالكامل */
+    table.approval-table,
+    table.departments-table,
+    table.departments-order-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 1.08em;
+      border-radius: 13px;
+      overflow: hidden;
+      background: #fff;
+      margin-bottom: 22px;
+      box-shadow: 0 1px 6px rgba(33,123,89,0.06);
+    }
+    table.approval-table th,
+    table.departments-table th,
+    table.departments-order-table th {
+      background: #f0f1f4;
+      color: #4d4d4d;
+      font-weight: bold;
+      font-size: 1.05em;
+      padding: 13px 6px 11px 6px;
+      border: 1px solid #ececec;
+      text-align: center;
+    }
+    table.approval-table td,
+    table.departments-table td,
+    table.departments-order-table td {
+      background: #fff;
+      color: #212b2c;
+      padding: 13px 6px 11px 6px;
+      border: 1px solid #ececec;
+      font-weight: 500;
+      font-size: 1em;
+      text-align: center;
+    }
+    table.approval-table tbody tr:nth-child(even),
+    table.departments-table tbody tr:nth-child(even),
+    table.departments-order-table tbody tr:nth-child(even) {
+      background: #f7fafd;
+    }
+    table.approval-table td,
+    table.approval-table th,
+    table.departments-table td,
+    table.departments-table th,
+    table.departments-order-table td,
+    table.departments-order-table th {
+      vertical-align: middle;
+    }
+    .status-success {
+      color: var(--status-success) !important;
+      font-weight: bold;
+    }
+    .status-pending {
+      color: var(--status-pending) !important;
+      font-weight: bold;
+    }
+    .status-danger {
+      color: var(--status-danger) !important;
+      font-weight: bold;
+    }
+    .status-icon {
+      font-size: 1.22em;
+      margin-left: 2px;
+      vertical-align: middle;
+    }
+    @media (max-width: 700px) {
+      table.approval-table,
+      table.departments-table,
+      table.departments-order-table {
+        font-size: 0.97em;
+      }
+      table.approval-table th, table.approval-table td,
+      table.departments-table th, table.departments-table td,
+      table.departments-order-table th, table.departments-order-table td {
+        padding: 7px 2px 7px 2px;
+      }
+    }
+    .action-final-box .final-title {
+      font-size:1.08em; display:flex;
+      align-items:center; gap:8px;
+      color:var(--main-green); margin-bottom:15px;
+      font-weight: 700;
+    }
+    .action-final-row {
+      display:flex; gap:14px; flex-wrap:wrap; margin-bottom:13px;
+      margin-right: 2px;
+    }
+    .action-final-row label {
+      display:flex; align-items:center; gap:8px;
+      padding:9px 17px;
+      border:1.1px solid var(--main-green-light);
+      border-radius:13px; cursor:pointer;
+      background: #f8faf8;
+      font-size: .98em;
+      transition: .16s;
+    }
+    .action-final-row input[type="radio"] { accent-color:var(--main-green); margin-left:8px; }
+    .action-final-row label:hover, .action-final-row input:focus + label {
+      border-color: var(--main-green);
+      background: #eaf9ed;
+    }
+    .btns {
+      display:flex; justify-content:flex-end; gap:13px;
+      margin-top: 14px;
+    }
+    .btns button {
+      padding:12px 28px; font-size:1em;
+      border:none; border-radius:10px;
+      color:#fff; background:var(--main-green);
+      cursor:pointer; transition:.19s;
+      font-weight: 600;
+      letter-spacing: 0.1px;
+      box-shadow: 0 2px 12px rgba(33,123,89,.05);
+    }
+    .btns button[name="submit"] { background:var(--main-green-light); color: #204f3d; }
+    .btns button:hover, .btns button:focus { filter:brightness(0.97); transform: translateY(-2px) scale(1.02);}
+    /* Departments table extra */
+    table.departments-table button {
+      background:none; border:none; cursor:pointer; font-size:1.14em; margin:0 4px;
+      color: #888;
+      transition: color .18s;
+    }
+    table.departments-table button:hover i { color:var(--main-green); }
+    table.departments-table button[title="حذف"] i { color:#c0392b; }
+    table.departments-table button[title="حذف"]:hover i { color:#d54f3c; }
+    /* ===== custom radio row ===== */
+    .custom-radio-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 28px;
+      flex-wrap: wrap;
+      margin-bottom: 16px;
+      position: relative;
+    }
+    .custom-radio-row .radio-hint {
+      font-size: 0.97em;
+      color: #3e684f;
+      font-weight: 500;
+      margin-left: 18px;
+      align-self: center;
+      background: #f3f9f2;
+      padding: 7px 18px;
+      border-radius: 12px;
+      border: 1px solid #e7eee8;
+      box-shadow: 0 2px 8px rgba(33,123,89,0.03);
+      margin-bottom: 0;
+    }
+    .custom-radio-row input[type="radio"] {
+      display: none;
+    }
+    .custom-radio-row label {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 8px 18px;
+      font-size: 1em;
+      border: 1.5px solid var(--main-green-light);
+      border-radius: 10px;
+      background: #f8faf8;
+      cursor: pointer;
+      font-weight: 700;
+      color: var(--main-green);
+      transition: .15s;
+      position: relative;
+      min-width: 80px;
+      justify-content: center;
+      box-shadow: 0 2px 8px rgba(33,123,89,0.04);
+    }
+    .custom-radio-row input[type="radio"]:checked + label {
+      background: linear-gradient(90deg, var(--main-green) 80%, var(--main-green-light) 100%);
+      color: #fff;
+      border-color: var(--main-green);
+      box-shadow: 0 5px 16px rgba(33,123,89,0.08);
+    }
+    .custom-radio-row label:hover,
+    .custom-radio-row input[type="radio"]:focus + label {
+      border-color: var(--main-green);
+      background: #eaf9ed;
+      color: var(--main-green);
+    }
+    .custom-radio-row label i {
+      font-size: 1.3em;
+    }
+    @media (max-width: 700px) {
+      .custom-radio-row {
+        flex-direction: column;
+        gap: 10px;
+      }
+      .custom-radio-row .radio-hint {
+        margin-bottom: 5px;
+        margin-left: 0;
+      }
+      .custom-radio-row label {
+        min-width: unset;
+        width: 100%;
+        justify-content: flex-start;
+      }
+    }
+    /* Responsive */
+    @media (max-width: 600px) {
+      .container, .steps-bar-wrapper { max-width:99vw; padding: 7px; }
+      .steps-bar::before { left:10px; right:10px; }
+      .step-icon { width:37px; height:37px; font-size:1.2em;}
+      .role-switcher { flex-wrap: wrap; gap:9px;}
+      h1 { font-size:1.1rem;}
+      th, td { font-size:0.92em;}
+      .details-box, .attachments-box, .action-final-box { padding:12px 8px 9px;}
+      .btns button { padding:10px 10px; font-size: 0.97em;}
+    }
+    .modal-bg {
+      display: none;
+      position: fixed;
+      z-index: 99999;
+      left: 0; top: 0;
+      width: 100%; height: 100%;
+      background: rgba(51, 51, 51, 0.18);
+      align-items: center;
+      justify-content: center;
+    }
+    .modal-bg.active {
+      display: flex;
+    }
+    .modal {
+      background: #fff;
+      border-radius: 13px;
+      box-shadow: 0 4px 24px rgba(34,70,53,0.11);
+      max-width: 360px;
+      width: 95vw;
+      padding: 34px 23px 23px 23px;
+      text-align: center;
+      border: 2px solid #e2ebdd;
+      position: relative;
+    }
+    .attachments-list a {
+      display: inline-block;
+      margin-bottom: 7px;
+      color: #217b59;
+      background: #f2f3f5;
+      padding: 8px 21px 8px 17px;
+      border-radius: 10px;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 15.5px;
+      transition: background 0.14s, color 0.15s;
+      margin-left: 7px;
+      border: 1px solid #e2e2e2;
+      box-shadow: 0 1px 4px -2px #d1d4d6;
+    }
+    .attachments-list a i {
+      margin-left: 4px;
+      font-size: 1.13em;
+      color: #858c93;
+    }
+    .attachments-list a:hover {
+      background: #e6e8eb;
+      color: #14553b;
+      border-color: #bfc6cc;
+    }
+    .last-updated-info {
+      display: block;
+      color: #555;
+      font-size: 0.99em;
+      margin-top: 8px;
+      margin-bottom: 0;
+      font-weight: 500;
+    }
+    .alert-instructions {
+      background: #f2fbf6;
+      color: #296847;
+      border: 1.2px solid #e3efe5;
+      border-radius: 11px;
+      padding: 13px 14px;
+      margin-bottom: 18px;
+      font-size: 1.06em;
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+    }
+    .alert-instructions i {
+      color: #168e62;
+      font-size: 1.23em;
+      margin-top: 2px;
+    }
+    .next-step-hint {
+      background: #f5faf9;
+      color: #1d7e59;
+      border: 1px solid #d8ece5;
+      padding: 9px 14px;
+      border-radius: 11px;
+      margin: 18px 0 0 0;
+      font-size: 1.01em;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }

--- a/ClientApp/src/app/app.routes.ts
+++ b/ClientApp/src/app/app.routes.ts
@@ -6,5 +6,6 @@ import { FetchDataComponent } from './fetch-data/fetch-data.component';
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'counter', component: CounterComponent },
-  { path: 'fetch-data', component: FetchDataComponent }
+  { path: 'fetch-data', component: FetchDataComponent },
+  { path: 'procurement-forms', loadComponent: () => import('./procurement-forms/procurement-forms.component').then(m => m.ProcurementFormsComponent) }
 ];

--- a/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -32,12 +32,15 @@
               >Counter</a
             >
           </li>
-          <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/fetch-data']"
-              >Fetch data</a
-            >
-          </li>
-        </ul>
+        <li class="nav-item" [routerLinkActive]="['link-active']">
+          <a class="nav-link text-dark" [routerLink]="['/fetch-data']"
+            >Fetch data</a
+          >
+        </li>
+        <li class="nav-item" [routerLinkActive]="['link-active']">
+          <a class="nav-link text-dark" [routerLink]="['/procurement-forms']">Forms</a>
+        </li>
+      </ul>
       </div>
     </div>
   </nav>

--- a/ClientApp/src/app/procurement-forms/completion.component.ts
+++ b/ClientApp/src/app/procurement-forms/completion.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-procurement-completion',
+  standalone: true,
+  imports: [RouterLink],
+  template: `<h2>تم إرسال الطلب بنجاح!</h2>
+             <a routerLink="/">العودة للصفحة الرئيسية</a>`
+})
+export class CompletionComponent {}

--- a/ClientApp/src/app/procurement-forms/manager-approval.component.html
+++ b/ClientApp/src/app/procurement-forms/manager-approval.component.html
@@ -1,0 +1,8 @@
+<h1>اعتماد مدير الإدارة</h1>
+<div class="details-box">
+  <p><strong>مدير المشروع:</strong> {{state.requester?.projectManager}}</p>
+  <p><strong>الإدارة:</strong> {{state.requester?.department}}</p>
+  <p><strong>التاريخ:</strong> {{state.requester?.date}}</p>
+  <p><strong>اسم المنافسة:</strong> {{state.requester?.competitionName}}</p>
+</div>
+<button class="main-btn submit-btn" (click)="next()">إنهاء</button>

--- a/ClientApp/src/app/procurement-forms/manager-approval.component.ts
+++ b/ClientApp/src/app/procurement-forms/manager-approval.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { ProcurementFormService } from './procurement-form.service';
+
+@Component({
+  selector: 'app-manager-approval',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './manager-approval.component.html'
+})
+export class ManagerApprovalComponent {
+  constructor(public state: ProcurementFormService, private router: Router) {}
+
+  next() {
+    this.router.navigate(['../complete']);
+  }
+}

--- a/ClientApp/src/app/procurement-forms/procurement-form.service.ts
+++ b/ClientApp/src/app/procurement-forms/procurement-form.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ProcurementFormService {
+  requester?: any;
+}

--- a/ClientApp/src/app/procurement-forms/procurement-forms.component.html
+++ b/ClientApp/src/app/procurement-forms/procurement-forms.component.html
@@ -1,0 +1,5 @@
+<div class="role-switcher">
+  <a class="role-btn" routerLink="request" routerLinkActive="active">مقدم الطلب</a>
+  <a class="role-btn" routerLink="manager-approval" routerLinkActive="active">مدير الإدارة</a>
+</div>
+<router-outlet></router-outlet>

--- a/ClientApp/src/app/procurement-forms/procurement-forms.component.ts
+++ b/ClientApp/src/app/procurement-forms/procurement-forms.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { RouterModule, Routes, RouterOutlet } from '@angular/router';
+import { RequesterFormComponent } from './requester-form.component';
+import { ManagerApprovalComponent } from './manager-approval.component';
+import { CompletionComponent } from './completion.component';
+
+export const procurementChildRoutes: Routes = [
+  { path: '', pathMatch: 'full', redirectTo: 'request' },
+  { path: 'request', component: RequesterFormComponent },
+  { path: 'manager-approval', component: ManagerApprovalComponent },
+  { path: 'complete', component: CompletionComponent }
+];
+
+@Component({
+  selector: 'app-procurement-forms',
+  standalone: true,
+  imports: [RouterModule.forChild(procurementChildRoutes), RouterOutlet],
+  templateUrl: './procurement-forms.component.html',
+  styleUrls: ['../../public/procurement/assets/main.css']
+})
+export class ProcurementFormsComponent {}

--- a/ClientApp/src/app/procurement-forms/requester-form.component.html
+++ b/ClientApp/src/app/procurement-forms/requester-form.component.html
@@ -1,0 +1,12 @@
+<h1>طلب طرح منافسة</h1>
+<form [formGroup]="form" class="details-box" (ngSubmit)="next()">
+  <label>مدير المشروع</label>
+  <input formControlName="projectManager" type="text" />
+  <label>الإدارة</label>
+  <input formControlName="department" type="text" />
+  <label>التاريخ</label>
+  <input formControlName="date" type="date" />
+  <label>اسم المنافسة</label>
+  <input formControlName="competitionName" type="text" />
+  <button class="main-btn submit-btn" type="submit">التالي</button>
+</form>

--- a/ClientApp/src/app/procurement-forms/requester-form.component.ts
+++ b/ClientApp/src/app/procurement-forms/requester-form.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { ProcurementFormService } from './procurement-form.service';
+
+@Component({
+  selector: 'app-requester-form',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink],
+  templateUrl: './requester-form.component.html'
+})
+export class RequesterFormComponent {
+  form = this.fb.group({
+    projectManager: ['', Validators.required],
+    department: ['', Validators.required],
+    date: ['', Validators.required],
+    competitionName: ['', Validators.required]
+  });
+
+  constructor(private fb: FormBuilder, private router: Router, private state: ProcurementFormService) {}
+
+  next() {
+    if (this.form.valid) {
+      this.state.requester = this.form.value;
+      this.router.navigate(['../manager-approval']);
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}

--- a/ClientApp/src/index.html
+++ b/ClientApp/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- replace DOM-based procurement forms component with Angular router and forms
- add minimal requester and manager approval steps using reactive forms
- remove unused partials and script assets
- expose forms page via navigation menu

## Testing
- `npm --prefix ClientApp run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623d97c98c8324bafa34df7549e0d8